### PR TITLE
Pass 'parse' option to escodegen

### DIFF
--- a/delta.js
+++ b/delta.js
@@ -414,10 +414,12 @@ function minimise(nd, parent, idx) {
 }
 
 function pp(ast) {
+    // we pass the 'parse' option here to avoid converting 0.0 to 0, etc.
     return escodegen.generate(ast, {
 	format: {
 	    json: ext === 'json'
-	}
+	},
+        parse: esprima.parse
     });
 }
 


### PR DESCRIPTION
This change prevents escodegen from modifying literals when serializing the AST, e.g., converting 0.0 to 0.

@xiemaisi @esbena look ok?  It's working in the run I'm trying now.  Would run the regression tests, but we don't have any...