### PR TITLE
Enable support for other source transformations during minification.

### DIFF
--- a/delta.js
+++ b/delta.js
@@ -151,9 +151,10 @@ if(predicate.transformations === undefined){
 	predicate.transformations = [];
 }
 if(optimize){
+	var closureCompilerJar = require('google-closure-compiler').compiler.jar_path;
 	function makeClosureCompilerTransformation(compilation_level){
 		return function(orig, transformed){
-			execSync(util.format("java -jar %s/node_modules/google-closure-compiler/compiler.jar --jscomp_off '*' --formatting PRETTY_PRINT --compilation_level %s --js %s --js_output_file %s", __dirname, compilation_level, orig, transformed));
+			execSync(util.format("java -jar %s --jscomp_off '*' --formatting PRETTY_PRINT --compilation_level %s --js %s --js_output_file %s", closureCompilerJar, compilation_level, orig, transformed));
 		}
 	}
 	predicate.transformations.push(makeClosureCompilerTransformation("ADVANCED_OPTIMIZATIONS"));

--- a/delta.js
+++ b/delta.js
@@ -466,7 +466,12 @@ function transformAndTest(transformation) {
     try {
 		console.log("Transforming candidate %s", orig);
         var transformed = getTempFileName();
-        transformation(orig, transformed);
+		try {
+			transformation(orig, transformed);
+		} catch (e) {
+			// ignore failures
+			return;
+		}
 
         // ensure termination of transformation fixpoint
         var sizeOrig = fs.statSync(orig).size;

--- a/delta.js
+++ b/delta.js
@@ -463,6 +463,12 @@ function test() {
  */
 function transformAndTest(transformation) {
     var orig = writeTempFile();
+
+	function getFileCodeSize(sourceFile) {
+		// The only reliable way of comparing transformed code sizes is to pretty print them in the same way
+		return pp(esprima.parse(fs.readFileSync(sourceFile))).length;
+	}
+
     try {
 		console.log("Transforming candidate %s", orig);
         var transformed = getTempFileName();
@@ -474,9 +480,8 @@ function transformAndTest(transformation) {
 		}
 
         // ensure termination of transformation fixpoint
-        var sizeOrig = fs.statSync(orig).size;
-        var sizeTransformed = fs.statSync(transformed).size;
-		var res = sizeTransformed + 8 /* sidestep padding choices */ < sizeOrig && predicate.test(transformed);
+		var reducedSize = getFileCodeSize(transformed) < getFileCodeSize(orig);
+        var res = reducedSize && predicate.test(transformed);
         if (res) {
             testSucceededAtLeastOnce = true;
 			// if the test succeeded, save it to file 'smallest'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "esprima": "2.2.0",
     "estraverse": "4.0.0",
     "execSync": "1.0.2",
+    "fs-extra": "^0.26.2",
     "google-closure-compiler": "^20151015.0.0"
   },
   "license": "Eclipse",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-    "name": "jsdelta",
-    "version": "0.3.1",
-    "author": "Max Schaefer <xiemaisi@gmail.com>",
-    "description": "A delta debugger for JavaScript",
-    "dependencies" : {
-      "escodegen": "1.6.1",
-      "esprima": "2.2.0",
-      "estraverse": "4.0.0",
-      "execSync": "1.0.2"
-    },
-    "license": "Eclipse",
-    "repository" : {
-      "type" : "git",
-      "url" : "https://github.com/wala/jsdelta.git"
-    },
-    "bin": {
-      "jsdelta": "./delta.js"
-    }
+  "name": "jsdelta",
+  "version": "0.3.1",
+  "author": "Max Schaefer <xiemaisi@gmail.com>",
+  "description": "A delta debugger for JavaScript",
+  "dependencies": {
+    "escodegen": "1.6.1",
+    "esprima": "2.2.0",
+    "estraverse": "4.0.0",
+    "execSync": "1.0.2",
+    "google-closure-compiler": "^20151015.0.0"
+  },
+  "license": "Eclipse",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wala/jsdelta.git"
+  },
+  "bin": {
+    "jsdelta": "./delta.js"
+  }
 }


### PR DESCRIPTION
Like the current ast-transformations, source transformations are only applied when they satisfy predicate.test().

- new npm-dependency: google-closure-compiler
- new option: --optimize, makes use of transformations in the google-closure-compiler
   - most important feature: enables the trivial minifications that jsdelta is incapable of, e.g. function-inlining, variable & property renaming
- new predicate-object-property: .transformers,  user-supplied source-to-source transformers
- minor cleanup/fixes

 The new features are *not* documented in the readme

 Example difference for the --optimize flag:

 Orig:
 ```
(function (){
  var o = {bar: 42};
  o.bar++;
})();
```
With --optimize:
```
(function () {
    var a = 42;
    a;
}());
```

Without --optimize
```
(function () {
    var o = { bar: 42 };
}());
```