### PR TITLE
Fix a bug in minimisation of ArrayExpressions.

### DIFF
--- a/delta.js
+++ b/delta.js
@@ -359,7 +359,7 @@ function minimise(nd, parent, idx) {
 					minimise_array(nd['arguments']);
 					break;
 				case 'ArrayExpression':
-					minimise_array(nd.elements, nd);
+					minimise_array(nd.elements);
 					break;
 				case 'IfStatement':
 				case 'ConditionalExpression':


### PR DESCRIPTION
The second argument passed to `minimise_array` was always truthy, hence preventing minimisation from removing all array elements.