### PR TITLE
Make default `tmp_dir` portable

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,4 +10,4 @@
  *******************************************************************************/
 
 // directory in which to create temporary files
-exports.tmp_dir = "/tmp";
+exports.tmp_dir = require('os').tmpdir();


### PR DESCRIPTION
This is technically a breaking change.

@amoeller 